### PR TITLE
feat: add ubuntu-based ami

### DIFF
--- a/.github/workflows/on-pr-aws.yaml
+++ b/.github/workflows/on-pr-aws.yaml
@@ -9,6 +9,10 @@ on:
       - "packer/scripts/**"
       - ".github/workflows/on-pr-aws.yaml"
 
+permissions:
+  id-token: write
+  contents: read
+      
 jobs:
   Test_AMI_Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pr-aws.yaml
+++ b/.github/workflows/on-pr-aws.yaml
@@ -10,7 +10,7 @@ on:
       - ".github/workflows/on-pr-aws.yaml"
 
 jobs:
-  fmt-validate-ami:
+  Test_AMI_Build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/on-pr-aws.yaml
+++ b/.github/workflows/on-pr-aws.yaml
@@ -1,0 +1,27 @@
+name: CI DUBBD RKE2
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packer/aws/**"
+      - "packer/scripts/**"
+      - ".github/workflows/on-pr-aws.yaml"
+
+jobs:
+  fmt-validate-ami:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_COMMERCIAL_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.job || github.event.client_payload.pull_request.head.sha || github.sha }}
+          aws-region: us-west-2
+          # 21600 seconds == 6 hours
+          role-duration-seconds: 21600
+      - name: Test Build
+        run: make test-ami

--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -1,20 +1,20 @@
 name: AWS AMI
 
 on:
-  pull_request:
+  push:
     branches:
       - main
     paths:
       - "packer/aws/**"
       - "packer/scripts/**"
-      - ".github/workflows/on-pr-aws.yaml"
+      - ".github/workflows/publish-aws.yaml"
 
 permissions:
   id-token: write
   contents: read
       
 jobs:
-  test:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -27,7 +27,5 @@ jobs:
           aws-region: us-west-2
           # 21600 seconds == 6 hours
           role-duration-seconds: 21600
-      - name: Validate AMI
-        run: make validate-ami
-      - name: Build AMI
-        run: make build-ami
+      - name: Publish AMI
+        run: make publish-ami

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+# Dirpaths for flavors
+AWS_DIR := packer/aws
+
+######################
+# Builds + Tests
+######################
+.PHONY: help
+help: ## Show this help message.
+	@grep -E '^[a-zA-Z_/-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| sort \
+		| awk 'BEGIN {FS = ":.*?## "; printf "\nUsage:\n"}; {printf "  %-15s %s\n", $$1, $$2}'
+	@echo
+
+.PHONY: build-ami
+build-ami: ## Build the AMI for AWS.
+	@cd $(AWS_DIR) && packer init . && packer build -var "ubuntu_pro_token=$(ubuntu_pro_token)" .
+
+.PHONY: test-ami
+test-ami: fmt-validate-ami ## Test the AMI build for AWS.
+	@cd $(AWS_DIR) && packer build -var "skip_create_ami=true" -var "ubuntu_pro_token=$(ubuntu_pro_token)" .
+
+.PHONY: fmt-validate-ami
+fmt-validate-ami: ## Run packer formatting and validation for the AWS AMI.
+	@cd $(AWS_DIR) && packer fmt .
+	@cd $(AWS_DIR) && packer init .
+	@cd $(AWS_DIR) && packer validate .

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 AWS_DIR := packer/aws
 
 ######################
-# Builds + Tests
+# Make Targets
 ######################
 .PHONY: help
 help: ## Show this help message.
@@ -11,16 +11,24 @@ help: ## Show this help message.
 		| awk 'BEGIN {FS = ":.*?## "; printf "\nUsage:\n"}; {printf "  %-15s %s\n", $$1, $$2}'
 	@echo
 
-.PHONY: build-ami
-build-ami: ## Build the AMI for AWS.
-	@cd $(AWS_DIR) && packer init . && packer build -var "ubuntu_pro_token=$(ubuntu_pro_token)" .
+.PHONY: publish-ami
+publish-ami: ## Build and Publish the AMI for AWS.
+	@cd $(AWS_DIR) && packer init .
+	@cd $(AWS_DIR) && packer build -var "ubuntu_pro_token=$(ubuntu_pro_token)" .
 
 .PHONY: test-ami
-test-ami: fmt-validate-ami ## Test the AMI build for AWS.
+test-ami: fmt-ami validate-ami build-ami ## fmt, validate, and build the AMI for AWS.
+
+.PHONY: build-ami
+build-ami: ## Build the AMI for AWS.
+	@cd $(AWS_DIR) && packer init .
 	@cd $(AWS_DIR) && packer build -var "skip_create_ami=true" -var "ubuntu_pro_token=$(ubuntu_pro_token)" .
 
-.PHONY: fmt-validate-ami
-fmt-validate-ami: ## Run packer formatting and validation for the AWS AMI.
+.PHONY: fmt-ami
+fmt-ami: ## Run packer fmt for the AWS AMI.
 	@cd $(AWS_DIR) && packer fmt .
+
+.PHONY: validate-ami
+validate-ami: ## Run packer validation for the AWS AMI.
 	@cd $(AWS_DIR) && packer init .
 	@cd $(AWS_DIR) && packer validate .

--- a/packer/aws/aws.pkr.hcl
+++ b/packer/aws/aws.pkr.hcl
@@ -1,0 +1,59 @@
+packer {
+  required_version = ">= 1.9.2"
+
+  required_plugins {
+    amazon = {
+      version = ">= 1.2.6"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+locals {
+  ami_name = var.timestamp ? lower("${var.ami_name}-${formatdate("YYYYMMDDhhmm", timestamp())}") : lower(var.ami_name)
+}
+
+source "amazon-ebs" "ubuntu" {
+  ami_name        = local.ami_name
+  ami_description = "For UDS deployments on RKE2"
+  instance_type   = "t2.micro"
+  region          = "us-west-2"
+  ssh_username    = "ubuntu"
+  source_ami      = var.base_ami
+
+  skip_create_ami = var.skip_create_ami
+}
+
+build {
+  name    = local.ami_name
+  sources = ["source.amazon-ebs.ubuntu"]
+
+  provisioner "shell" {
+    environment_vars = [
+      "UBUNTU_PRO_TOKEN=${var.ubuntu_pro_token}"
+    ]
+    // STIG-ing must be run as root
+    execute_command   = "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
+    script            = "../scripts/stig.sh"
+    expect_disconnect = length(var.ubuntu_pro_token) > 0
+    timeout           = "20m"
+  }
+
+  provisioner "shell" {
+    environment_vars = [
+      "INSTALL_RKE2_VERSION=${var.rke2_version}"
+    ]
+    // RKE2 artifact unpacking/install must be run as root
+    execute_command = "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
+    script          = "../scripts/rke2-install.sh"
+    timeout         = "15m"
+  }
+
+  provisioner "shell" {
+    // RKE2 artifact unpacking/install must be run as root
+    execute_command = "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
+    script          = "../scripts/os-prep.sh"
+    timeout         = "15m"
+  }
+
+}

--- a/packer/aws/variables.pkr.hcl
+++ b/packer/aws/variables.pkr.hcl
@@ -1,0 +1,37 @@
+variable "ami_name" {
+  type        = string
+  description = "Name to use for the published AMI"
+  default     = "uds-rke2"
+}
+
+variable "timestamp" {
+  type        = bool
+  description = "Append a timestamp to the end of the published AMI name"
+  default     = true
+}
+
+variable "base_ami" {
+  type        = string
+  description = "AMI to build on top of, scripts validated on Ubuntu 20.04"
+  // ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230725
+  default = "ami-03fc394d884ee7d48"
+}
+
+variable "rke2_version" {
+  type        = string
+  description = "RKE2 version to install on the AMI"
+  default     = "v1.26.7+rke2r1"
+}
+
+variable "ubuntu_pro_token" {
+  type        = string
+  description = "Token for a valid Ubuntu Pro subscription to use for FIPS packages"
+  default     = ""
+  sensitive   = true
+}
+
+variable "skip_create_ami" {
+  type        = bool
+  description = "Build, but skip creation of an AMI"
+  default     = false
+}

--- a/packer/scripts/os-prep.sh
+++ b/packer/scripts/os-prep.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+echo "Performing OS prep necessary for DUBBD on RKE2..."
+
+iptables -A INPUT -p tcp -m tcp --dport 2379 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p tcp -m tcp --dport 2380 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p tcp -m tcp --dport 9345 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p tcp -m tcp --dport 6443 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p udp -m udp --dport 8472 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p tcp -m tcp --dport 10250 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p tcp -m tcp --dport 30000:32767 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p tcp -m tcp --dport 4240 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p tcp -m tcp --dport 179 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p udp -m udp --dport 4789 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p tcp -m tcp --dport 5473 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p tcp -m tcp --dport 9098 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p tcp -m tcp --dport 9099 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p udp -m udp --dport 51820 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p udp -m udp --dport 51821 -m state --state NEW -j ACCEPT
+iptables -A INPUT -p icmp --icmp-type 8 -m state --state NEW,ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -p icmp --icmp-type 0 -m state --state ESTABLISHED,RELATED -j ACCEPT
+iptables-save
+
+echo "* soft nofile 13181250" >> /etc/security/limits.d/ulimits.conf
+echo "* hard nofile 13181250" >> /etc/security/limits.d/ulimits.conf
+echo "* soft nproc  13181250" >> /etc/security/limits.d/ulimits.conf
+echo "* hard nproc  13181250" >> /etc/security/limits.d/ulimits.conf
+
+sysctl -w vm.max_map_count=524288
+echo "vm.max_map_count=524288" > /etc/sysctl.d/vm-max_map_count.conf
+
+sysctl -w fs.nr_open=13181252
+echo "fs.nr_open=13181252" > /etc/sysctl.d/fs-nr_open.conf
+
+sysctl -w fs.file-max=13181250
+echo "fs.file-max=13181250" > /etc/sysctl.d/fs-file-max.conf
+
+echo "fs.inotify.max_user_instances=1024" > /etc/sysctl.d/fs-inotify-max_user_instances.conf
+sysctl -w fs.inotify.max_user_instances=1024
+
+echo "fs.inotify.max_user_watches=1048576" > /etc/sysctl.d/fs-inotify-max_user_watches.conf
+sysctl -w fs.inotify.max_user_watches=1048576
+
+echo "vm.overcommit_memory=1" >> /etc/sysctl.d/90-kubelet.conf
+sysctl -w vm.overcommit_memory=1
+echo "kernel.panic=10" >> /etc/sysctl.d/90-kubelet.conf
+sysctl -w kernel.panic=10
+echo "kernel.panic_on_oops=1" >> /etc/sysctl.d/90-kubelet.conf
+sysctl -w kernel.panic_on_oops=1
+
+sysctl -p
+
+modprobe br_netfilter
+modprobe xt_REDIRECT
+modprobe xt_owner
+modprobe xt_statistic
+echo "br_netfilter" >> /etc/modules-load.d/istio-iptables.conf
+echo "xt_REDIRECT" >> /etc/modules-load.d/istio-iptables.conf
+echo "xt_owner" >> /etc/modules-load.d/istio-iptables.conf
+echo "xt_statistic" >> /etc/modules-load.d/istio-iptables.conf

--- a/packer/scripts/rke2-install.sh
+++ b/packer/scripts/rke2-install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "Installing RKE2 $INSTALL_RKE2_VERSION..."
+
+# Stage image artifacts
+mkdir -p /var/lib/rancher/rke2/agent/images/ && cd /var/lib/rancher/rke2/agent/images/
+curl -LO "https://github.com/rancher/rke2/releases/download/$INSTALL_RKE2_VERSION/rke2-images-core.linux-amd64.tar.zst"
+curl -LO "https://github.com/rancher/rke2/releases/download/$INSTALL_RKE2_VERSION/rke2-images-canal.linux-amd64.tar.zst"
+
+# Stage RKE2 install scripts/binary
+mkdir -p /root/rke2-artifacts && cd /root/rke2-artifacts/
+curl -LO "https://github.com/rancher/rke2/releases/download/$INSTALL_RKE2_VERSION/rke2-images.linux-amd64.tar.zst"
+curl -LO "https://github.com/rancher/rke2/releases/download/$INSTALL_RKE2_VERSION/rke2.linux-amd64.tar.gz"
+curl -LO "https://github.com/rancher/rke2/releases/download/$INSTALL_RKE2_VERSION/sha256sum-amd64.txt"
+curl -sfL https://get.rke2.io --output install.sh
+
+# Run install script
+cd /root/rke2-artifacts/ && chmod +x install.sh
+INSTALL_RKE2_ARTIFACT_PATH=/root/rke2-artifacts ./install.sh

--- a/packer/scripts/stig.sh
+++ b/packer/scripts/stig.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "Executing STIG automation..."
+
+# Install ansible and unzip utils
+echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+apt-add-repository ppa:ansible/ansible -y
+apt-get update -y && apt-get upgrade -y
+apt-get install ansible unzip -y
+
+# Pull Ansible STIGs from https://public.cyber.mil/stigs/supplemental-automation-content/
+mkdir -p /tmp/ansible && chmod 700 /tmp/ansible && cd /tmp/ansible
+curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_CAN_Ubuntu_20-04_LTS_V1R9_STIG_Ansible.zip
+unzip ansible.zip
+unzip ubuntu2004STIG-ansible.zip
+chmod +x enforce.sh && ./enforce.sh
+
+# Cleanup temp files and utils
+apt-get remove ansible unzip -y
+apt-get autoremove -y
+cd && rm -rf /tmp/*
+
+# FIPS - Conditionally performed based of subscription being provided
+if [[ $UBUNTU_PRO_TOKEN ]]; then
+  pro attach $UBUNTU_PRO_TOKEN
+  apt-get install ubuntu-advantage-tools -y
+  pro enable fips-updates --assume-yes # TBD should this just be the `fips` "certified" install?
+  reboot # Reboot to enable FIPS before proceeding
+fi


### PR DESCRIPTION
Adds initial packer to build AWS AMI:
- Ubuntu 20 base
- Ansible STIG-ing from DISA
- Conditional FIPS enabling with a subscription
- RKE2 install for airgap
- "OS prep" for RKE2/DUBBD

Also adds CI that tests the build on PR and publishes to the CI AWS account on push to main.

Related to https://github.com/defenseunicorns/uds-rke2-image-builder/issues/1