### PR TITLE
feat: add aws-cli

### DIFF
--- a/packer/aws/aws.pkr.hcl
+++ b/packer/aws/aws.pkr.hcl
@@ -56,4 +56,9 @@ build {
     timeout         = "15m"
   }
 
+  provisioner "shell" {
+    inline  = ["sudo apt-get install awscli -y"]
+    timeout = "15m"
+  }
+
 }


### PR DESCRIPTION
Discovered during https://github.com/defenseunicorns/uds-package-dubbd/pull/508 that aws-cli is required by the terraform modules being used currently. This could be bypassed with different modules but for simplicity and not developing our own modules it seems useful to add it to the AMI.