### PR TITLE
Add workflow steps to link jobs triggered by slash commands to PR status

### DIFF
--- a/.github/workflows/test-rke2-cluster.yaml
+++ b/.github/workflows/test-rke2-cluster.yaml
@@ -8,6 +8,7 @@ permissions:
   id-token: write
   contents: write # For executing the repository_dispatch event
   pull-requests: write # For doing the emoji reaction on a PR comment
+  statuses: write
 
 defaults:
   run:
@@ -85,6 +86,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+      
+      # Update GitHub status for pending pipeline run
+      - name: "Update GitHub Status for pending"
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state pending -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT: Test ${{ matrix.test-distros }} AMI
+          GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
@@ -109,3 +125,51 @@ jobs:
       - name: Teardown test infrastructure
         if: always()
         run: make teardown-infra
+
+      # Update GitHub status for successful pipeline run
+      - name: "Update GitHub Status for success"
+        if: ${{ success() }}
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state success -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT: Test ${{ matrix.test-distros }} AMI
+          GITHUB_DESCRIPTION: "run passed"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+      # Update GitHub status for failing pipeline run
+      - name: "Update GitHub Status for failure"
+        if: ${{ failure() }}
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state failure -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT: Test ${{ matrix.test-distros }} AMI
+          GITHUB_DESCRIPTION: "run failed"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+      # Update GitHub status for cancelled pipeline run
+      - name: "Update GitHub Status for cancelled"
+        if: ${{ cancelled() }}
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state error -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTEXT: Test ${{ matrix.test-distros }} AMI
+          GITHUB_DESCRIPTION: "run cancelled"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}


### PR DESCRIPTION
Added workflow steps and token permissions needed to link jobs that are triggered from slash commands to the PR they are triggered from. 