### PR TITLE
fix: cleanup machine-id on nutanix

### DIFF
--- a/packer/nutanix/README.md
+++ b/packer/nutanix/README.md
@@ -38,4 +38,6 @@ make build-nutanix
 
 ## Using the Image
 
-Once your image is built and "published" you can spin up a VM using it. Attach a disk, set to clone from the image you created, and resize it accordingly to your needs for the root disk. You will also need to use cloud-init to setup an initial user. An example of this is used for the Packer build to create a user `builder` with the password `packer` and sudo privileges (check it out [here](./cloud-config.yaml)).
+Once your image is built and "published" you can spin up a VM using it. Attach a disk, set to clone from the image you created, and resize it accordingly to your needs for the root disk. You will also likely want to use cloud-init for a few things:
+- Setup an initial user (no default user exists in these built images): See [here](./cloud-config.yaml) for a basic example adding a user `packer` with the password `builder`.
+- Set a unique hostname (default will likely be `ubuntu` on Ubuntu and `localhost` on RHEL): See [here](https://cloudinit.readthedocs.io/en/latest/reference/modules.html#set-hostname) for example formatting to add to your cloud-init.

--- a/packer/nutanix/nutanix.pkr.hcl
+++ b/packer/nutanix/nutanix.pkr.hcl
@@ -93,4 +93,10 @@ build {
     script          = "../scripts/cleanup-deps.sh"
     timeout         = "15m"
   }
+
+  provisioner "shell" {
+    execute_command = "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
+    script          = "../scripts/cleanup-cloud-init.sh"
+    timeout         = "15m"
+  }
 }

--- a/packer/scripts/cleanup-cloud-init.sh
+++ b/packer/scripts/cleanup-cloud-init.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Cleanup cloud-init and machine-id, this is generally only needed for non-AWS environments
+
+# Detect distro. This works fine with only rhel and ubuntu in the list, but will not work as is if you need to distinguish ubuntu/debian or rhel/fedora
+DISTRO=$( cat /etc/os-release | tr [:upper:] [:lower:] | grep -Poi '(ubuntu|rhel)' | uniq )
+
+cloud-init clean
+
+if [[ $DISTRO == "rhel" ]]; then
+  rm -rf /etc/machine-id
+elif [[ $DISTRO == "ubuntu" ]]; then
+  cloud-init clean --machine-id
+else
+  echo "$DISTRO not an expected distribution."
+fi


### PR DESCRIPTION
`/etc/machine-id` was persisting on the built image, so running some cloud-init cleanup to ensure everything is unique and can grab unique IPs.