### PR TITLE
Update DISA STIG artifact versions

### DIFF
--- a/packer/scripts/os-stig.sh
+++ b/packer/scripts/os-stig.sh
@@ -7,9 +7,9 @@ DISTRO=$( cat /etc/os-release | tr [:upper:] [:lower:] | grep -Poi '(ubuntu|rhel
 # Pull Ansible STIGs from https://public.cyber.mil/stigs/supplemental-automation-content/
 mkdir -p /tmp/ansible && chmod 700 /tmp/ansible && cd /tmp/ansible
 if [[ $DISTRO == "rhel" ]]; then
-  curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_RHEL_8_V1R11_STIG_Ansible.zip
+  curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_RHEL_8_V1R12_STIG_Ansible.zip
 elif [[ $DISTRO == "ubuntu" ]]; then
-  curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_CAN_Ubuntu_20-04_LTS_V1R9_STIG_Ansible.zip
+  curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_CAN_Ubuntu_20-04_LTS_V1R10_STIG_Ansible.zip
 fi
 unzip ansible.zip
 unzip *-ansible.zip


### PR DESCRIPTION
DISA published new revisions and the old ones were nuked. Updating to the new revisions to fix.

Probably need to mirror these artifacts somewhere in the future.