### PR TITLE
chore: remove iptables from builder, fix dir locations

### DIFF
--- a/docs/builder-steps.md
+++ b/docs/builder-steps.md
@@ -27,7 +27,6 @@ The [RKE2 Install script](../packer/scripts/rke2-install.sh) installs RKE2, suit
 ## OS Preparation
 
 The [OS Preparation script](../packer/scripts/os-prep.sh) changes a number of things on the base OS to ensure smooth operation of RKE2 and UDS pieces running on top such as [DUBBD](https://github.com/defenseunicorns/uds-package-dubbd). Requirements were pulled from upstream documentation:
-- [RKE2 Networking (iptables) requirements](https://docs.rke2.io/install/requirements#networking)
 - Big Bang sysctl/SELinux requirements: [general requirements](https://docs-bigbang.dso.mil/latest/docs/prerequisites/os-preconfiguration/) and [logging specific requirements](https://docs-bigbang.dso.mil/latest/packages/fluentbit/docs/TROUBLESHOOTING/?h=fs.inotify.max_user_watches%2F#Too-many-open-files)
 - Handling prerequisite requirements: Modifying network manager and disabling services that conflict with cluster networking (see [this](https://docs.rke2.io/known_issues#firewalld-conflicts-with-default-networking) and [this](https://docs.rke2.io/known_issues#networkmanager))
 

--- a/packer/scripts/install-deps.sh
+++ b/packer/scripts/install-deps.sh
@@ -7,7 +7,7 @@ DISTRO=$( cat /etc/os-release | tr [:upper:] [:lower:] | grep -Poi '(ubuntu|rhel
 # Install dependencies and cli tools needed by other packer scripts
 if [[ $DISTRO == "rhel" ]]; then
   yum update -y && yum upgrade -y
-  yum install ansible unzip iptables nftables -y
+  yum install ansible unzip -y
   #  Install rke2 selinux policy
   curl -LO "https://github.com/rancher/rke2-selinux/releases/download/v0.14.stable.1/rke2-selinux-0.14-1.el8.noarch.rpm"
   yum install rke2-selinux-0.14-1.el8.noarch.rpm -y
@@ -15,7 +15,7 @@ elif [[ $DISTRO == "ubuntu" ]]; then
   echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
   apt-add-repository ppa:ansible/ansible -y
   apt-get update -y && apt-get upgrade -y
-  apt-get install ansible unzip iptables-persistent jq -y
+  apt-get install ansible unzip jq -y
 fi
 
 # Ensure that ansible collections needed are installed 

--- a/packer/scripts/rke2-startup.sh
+++ b/packer/scripts/rke2-startup.sh
@@ -67,23 +67,23 @@ find $dir -maxdepth 1 -type f -name "*.kubeconfig" -exec chmod 0640 {} \;
 find $dir -maxdepth 1 -type f -name "*.crt" -exec chmod 0600 {} \;
 find $dir -maxdepth 1 -type f -name "*.key" -exec chmod 0600 {} \;
 
-dir=/var/lib/rancher/rke2/agent/bin
+dir=/var/lib/rancher/rke2/bin
 chown root:root $dir/*
 chmod 0750 $dir/*
 
-dir=/var/lib/rancher/rke2/agent
-chown root:root $dir/data
-chmod 0750 $dir/data
-
 dir=/var/lib/rancher/rke2/data
+chown root:root $dir
+chmod 0750 $dir
 chown root:root $dir/*
 chmod 0640 $dir/*
 
-dir=/var/lib/rancher/rke2/server
-chown root:root $dir/*
-chmod 0700 $dir/cred
-chmod 0700 $dir/db
-chmod 0700 $dir/tls
-chmod 0751 $dir/manifests
-chmod 0750 $dir/logs
-chmod 0600 $dir/token
+if [ -z $agent ]; then
+  dir=/var/lib/rancher/rke2/server
+  chown root:root $dir/*
+  chmod 0700 $dir/cred
+  chmod 0700 $dir/db
+  chmod 0700 $dir/tls
+  chmod 0751 $dir/manifests
+  chmod 0750 $dir/logs
+  chmod 0600 $dir/token
+fi

--- a/packer/scripts/rke2-startup.sh
+++ b/packer/scripts/rke2-startup.sh
@@ -77,13 +77,11 @@ chmod 0750 $dir
 chown root:root $dir/*
 chmod 0640 $dir/*
 
-if [ -z $agent ]; then
-  dir=/var/lib/rancher/rke2/server
-  chown root:root $dir/*
-  chmod 0700 $dir/cred
-  chmod 0700 $dir/db
-  chmod 0700 $dir/tls
-  chmod 0751 $dir/manifests
-  chmod 0750 $dir/logs
-  chmod 0600 $dir/token
-fi
+dir=/var/lib/rancher/rke2/server
+chown root:root $dir/*
+chmod 0700 $dir/cred
+chmod 0700 $dir/db
+chmod 0700 $dir/tls
+chmod 0751 $dir/manifests
+chmod 0750 $dir/logs
+chmod 0600 $dir/token


### PR DESCRIPTION
After further testing these iptables can cause issues with calico startup in some scenarios. Evaluating their value:
- They do not have access to the correct ip ranges (server/agent node ranges which aren't known at build time)
- They don't actually lock down at all unless a default iptables blocking rule gets added
- AWS/other environment firewall rules are required and where real logic should be implemented

Also included a fix for the directories that need to change permissions (and made the server one conditional).