### PR TITLE
Update rke2

### DIFF
--- a/packer/aws/aws.pkr.hcl
+++ b/packer/aws/aws.pkr.hcl
@@ -23,7 +23,7 @@ data "amazon-ami" "base-ami" {
 }
 
 source "amazon-ebs" "base" {
-  ami_name        = {{local.ami_name | clean_resource_name}}
+  ami_name        = "{{local.ami_name | clean_resource_name}}"
   ami_description = "For UDS deployments on RKE2"
   instance_type   = "t2.micro"
   region          = var.region
@@ -34,7 +34,7 @@ source "amazon-ebs" "base" {
 }
 
 build {
-  name    = {{local.ami_name | clean_resource_name}}
+  name    = "{{local.ami_name | clean_resource_name}}"
   sources = ["source.amazon-ebs.base"]
 
   // Ubuntu Pro subscription attachment happens during cloud-init when using a Pro AMI

--- a/packer/aws/aws.pkr.hcl
+++ b/packer/aws/aws.pkr.hcl
@@ -23,7 +23,7 @@ data "amazon-ami" "base-ami" {
 }
 
 source "amazon-ebs" "base" {
-  ami_name        = local.ami_name
+  ami_name        = {{local.ami_name | clean_resource_name}}
   ami_description = "For UDS deployments on RKE2"
   instance_type   = "t2.micro"
   region          = var.region
@@ -34,7 +34,7 @@ source "amazon-ebs" "base" {
 }
 
 build {
-  name    = local.ami_name
+  name    = {{local.ami_name | clean_resource_name}}
   sources = ["source.amazon-ebs.base"]
 
   // Ubuntu Pro subscription attachment happens during cloud-init when using a Pro AMI

--- a/packer/aws/aws.pkr.hcl
+++ b/packer/aws/aws.pkr.hcl
@@ -10,7 +10,7 @@ packer {
 }
 
 locals {
-  ami_name = var.timestamp ? lower("${var.ami_name}-${formatdate("YYYYMMDDhhmm", timestamp())}") : lower(var.ami_name)
+  ami_name = var.timestamp ? lower("${var.ami_name}-${var.rke2_version}-${formatdate("YYYYMMDDhhmm", timestamp())}") : lower(var.ami_name)
 }
 
 data "amazon-ami" "base-ami" {

--- a/packer/aws/aws.pkr.hcl
+++ b/packer/aws/aws.pkr.hcl
@@ -10,7 +10,7 @@ packer {
 }
 
 locals {
-  ami_name = var.timestamp ? lower("${var.ami_name}-${var.rke2_version}-${formatdate("YYYYMMDDhhmm", timestamp())}") : lower(var.ami_name)
+  ami_name = var.timestamp ? lower("${var.ami_name}-${replace(var.rke2_version, "+", "-")}-${formatdate("YYYYMMDDhhmm", timestamp())}") : lower("${var.ami_name}-${replace(var.rke2_version, "+", "-")}")
 }
 
 data "amazon-ami" "base-ami" {
@@ -23,7 +23,7 @@ data "amazon-ami" "base-ami" {
 }
 
 source "amazon-ebs" "base" {
-  ami_name        = "{{local.ami_name | clean_resource_name}}"
+  ami_name        = local.ami_name
   ami_description = "For UDS deployments on RKE2"
   instance_type   = "t2.micro"
   region          = var.region
@@ -34,7 +34,7 @@ source "amazon-ebs" "base" {
 }
 
 build {
-  name    = "{{local.ami_name | clean_resource_name}}"
+  name    = local.ami_name
   sources = ["source.amazon-ebs.base"]
 
   // Ubuntu Pro subscription attachment happens during cloud-init when using a Pro AMI

--- a/packer/aws/rhel.pkrvars.hcl
+++ b/packer/aws/rhel.pkrvars.hcl
@@ -1,5 +1,5 @@
 // Input variable values for a RHEL based RKE2 AMI
-ami_name      = "uds-rke2-rhel"
+ami_name      = "uds-rhel-rke2"
 base_ami_name = "RHEL-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2"
 ssh_username  = "ec2-user"
 base_ami_owners = ["amazon", "219670896067"]

--- a/packer/aws/ubuntu.pkrvars.hcl
+++ b/packer/aws/ubuntu.pkrvars.hcl
@@ -1,5 +1,5 @@
 // Input variable values for an Ubuntu based RKE2 AMI
-ami_name      = "uds-rke2-ubuntu"
+ami_name      = "uds-ubuntu-rke2"
 base_ami_name = "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-202*"
 ssh_username  = "ubuntu"
 base_ami_owners = ["amazon", "513442679011"] # 513442679011 is Ubuntu if GovCloud

--- a/packer/aws/variables.pkr.hcl
+++ b/packer/aws/variables.pkr.hcl
@@ -17,7 +17,7 @@ variable "base_ami_name" {
 variable "rke2_version" {
   type        = string
   description = "RKE2 version to install on the AMI"
-  default     = "v1.29.1+rke2r1"
+  default     = "v1.28.6+rke2r1"
 }
 
 variable "ubuntu_pro_token" {

--- a/packer/aws/variables.pkr.hcl
+++ b/packer/aws/variables.pkr.hcl
@@ -17,7 +17,7 @@ variable "base_ami_name" {
 variable "rke2_version" {
   type        = string
   description = "RKE2 version to install on the AMI"
-  default     = "v1.27.6+rke2r1"
+  default     = "v1.29.1+rke2r1"
 }
 
 variable "ubuntu_pro_token" {

--- a/packer/nutanix/nutanix.pkr.hcl
+++ b/packer/nutanix/nutanix.pkr.hcl
@@ -41,6 +41,7 @@ source "nutanix" "base" {
   image_export     = var.image_export
   force_deregister = true
   vm_force_delete  = true
+  boot_type        = "uefi"
 
   // Startup / Connection / Shutdown Details
   user_data        = base64encode(file("cloud-config.yaml"))

--- a/packer/nutanix/nutanix.pkr.hcl
+++ b/packer/nutanix/nutanix.pkr.hcl
@@ -10,7 +10,7 @@ packer {
 }
 
 locals {
-  img_name = var.timestamp ? lower("${var.output_image_name}-${formatdate("YYYYMMDDhhmm", timestamp())}") : lower(var.output_image_name)
+  img_name = var.timestamp ? lower("${var.output_image_name}-${rke2_version}-${formatdate("YYYYMMDDhhmm", timestamp())}") : lower(var.output_image_name)
 }
 
 source "nutanix" "base" {

--- a/packer/nutanix/nutanix.pkr.hcl
+++ b/packer/nutanix/nutanix.pkr.hcl
@@ -10,7 +10,7 @@ packer {
 }
 
 locals {
-  img_name = var.timestamp ? lower("${var.output_image_name}-${rke2_version}-${formatdate("YYYYMMDDhhmm", timestamp())}") : lower(var.output_image_name)
+  img_name = var.timestamp ? lower("${var.output_image_name}-${var.rke2_version}-${formatdate("YYYYMMDDhhmm", timestamp())}") : lower(var.output_image_name)
 }
 
 source "nutanix" "base" {

--- a/packer/nutanix/nutanix.pkr.hcl
+++ b/packer/nutanix/nutanix.pkr.hcl
@@ -10,7 +10,7 @@ packer {
 }
 
 locals {
-  img_name = var.timestamp ? lower("${var.output_image_name}-${var.rke2_version}-${formatdate("YYYYMMDDhhmm", timestamp())}") : lower(var.output_image_name)
+  img_name = var.timestamp ? lower("${var.output_image_name}-${var.rke2_version}-${formatdate("YYYYMMDDhhmm", timestamp())}") : lower("${var.output_image_name}-${var.rke2_version}")
 }
 
 source "nutanix" "base" {

--- a/packer/nutanix/variables.pkr.hcl
+++ b/packer/nutanix/variables.pkr.hcl
@@ -17,7 +17,7 @@ variable "base_image_name" {
 variable "rke2_version" {
   type        = string
   description = "RKE2 version to install on the Image"
-  default     = "v1.27.6+rke2r1"
+  default     = "v1.29.0+rke2r1"
 }
 
 variable "ubuntu_pro_token" {

--- a/packer/nutanix/variables.pkr.hcl
+++ b/packer/nutanix/variables.pkr.hcl
@@ -17,7 +17,7 @@ variable "base_image_name" {
 variable "rke2_version" {
   type        = string
   description = "RKE2 version to install on the Image"
-  default     = "v1.29.0+rke2r1"
+  default     = "v1.29.1+rke2r1"
 }
 
 variable "ubuntu_pro_token" {

--- a/packer/nutanix/variables.pkr.hcl
+++ b/packer/nutanix/variables.pkr.hcl
@@ -17,7 +17,7 @@ variable "base_image_name" {
 variable "rke2_version" {
   type        = string
   description = "RKE2 version to install on the Image"
-  default     = "v1.29.1+rke2r1"
+  default     = "v1.28.6+rke2r1"
 }
 
 variable "ubuntu_pro_token" {

--- a/packer/scripts/cleanup-cloud-init.sh
+++ b/packer/scripts/cleanup-cloud-init.sh
@@ -7,7 +7,7 @@ DISTRO=$( cat /etc/os-release | tr [:upper:] [:lower:] | grep -Poi '(ubuntu|rhel
 # Cleanup cloud-init and machine-id, this is generally only needed for non-AWS environments
 cloud-init clean
 if [[ $DISTRO == "rhel" ]]; then
-  rm -rf /etc/machine-id
+  truncate -s 0 /etc/machine-id
 elif [[ $DISTRO == "ubuntu" ]]; then
   cloud-init clean --machine-id
 fi

--- a/packer/scripts/os-prep.sh
+++ b/packer/scripts/os-prep.sh
@@ -27,7 +27,7 @@ for module in "${modules[@]}"; do
 done
 
 # cgroupsv2 for RKE2 + NeuVector
-sed -i 's/GRUB_CMDLINE_LINUX=\"/GRUB_CMDLINE_LINUX=\"systemd.unified_cgroup_hierarchy=1/' /etc/default/grub
+sed -i 's/GRUB_CMDLINE_LINUX=\"/GRUB_CMDLINE_LINUX=\"systemd.unified_cgroup_hierarchy=1 /' /etc/default/grub
 BOOT_TYPE=$([ -d /sys/firmware/efi ] && echo UEFI || echo BIOS)
 if [[ $DISTRO == "rhel" ]]; then
   if [[ $BOOT_TYPE == "BIOS" ]]; then

--- a/packer/scripts/os-stig.sh
+++ b/packer/scripts/os-stig.sh
@@ -7,7 +7,7 @@ DISTRO=$( cat /etc/os-release | tr [:upper:] [:lower:] | grep -Poi '(ubuntu|rhel
 # Pull Ansible STIGs from https://public.cyber.mil/stigs/supplemental-automation-content/
 mkdir -p /tmp/ansible && chmod 700 /tmp/ansible && cd /tmp/ansible
 if [[ $DISTRO == "rhel" ]]; then
-  curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_RHEL_8_V1R12_STIG_Ansible.zip
+  curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_RHEL_8_V1R13_STIG_Ansible.zip
 elif [[ $DISTRO == "ubuntu" ]]; then
   curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_CAN_Ubuntu_20-04_LTS_V1R10_STIG_Ansible.zip
 fi


### PR DESCRIPTION
* Update to latest RKE2 release that contains fix for runc CVE
* Update os-prep.sh script to include a space after added grub option. This is necessary to account for existing grub options
* Update cleanup-cloud-init.sh to use truncate for RHEL /etc/machine-id instead of removing the file. This change is due to new VMs sometimes not having an /etc/machine-id file created on startup which causes a directory to be created when a container tries to mount the machine-id.
* Added RKE2 version to image name for Nutanix builds