### PR TITLE
chore: switch from terraform to tofu

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -28,10 +28,11 @@ runs:
         GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
 
-    - uses: hashicorp/setup-terraform@v3
+    - name: Setup Tofu
+      uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3
       with:
-        terraform_version: "1.5.7"
-        terraform_wrapper: false
+        tofu_wrapper: false
+        tofu_version: 1.6.2
 
     - name: Setup UDS
       if: always()

--- a/.github/test-infra/rke2-cluster/main.tf
+++ b/.github/test-infra/rke2-cluster/main.tf
@@ -5,7 +5,6 @@ provider "aws" {
 terraform {
   backend "s3" {
   }
-  required_version = ">= 1.0.0, < 1.6.0"
 }
 
 data "aws_vpc" "vpc" {

--- a/.github/test-infra/scripts/get-kubeconfig.sh
+++ b/.github/test-infra/scripts/get-kubeconfig.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-# Utility script that can be called from a uds task after terraform has deployed the e2e test module
+# Utility script that can be called from a uds task after tofu has deployed the e2e test module
 
-echo "terraform version: $(terraform --version)"
+echo "tofu version: $(tofu --version)"
 
-# Get required outputs from terraform
-terraform output -raw private_key > key.pem
+# Get required outputs from tofu
+tofu output -raw private_key > key.pem
 chmod 600 key.pem
 
-bootstrap_ip=$(terraform output -raw bootstrap_ip)
+bootstrap_ip=$(tofu output -raw bootstrap_ip)
 echo "bootstrap_ip: ${bootstrap_ip}"
 
-node_user=$(terraform output -raw node_user)
+node_user=$(tofu output -raw node_user)
 echo "node_user: ${node_user}"
 
-cluster_hostname=$(terraform output -raw cluster_hostname)
+cluster_hostname=$(tofu output -raw cluster_hostname)
 echo "cluster_hostname: ${cluster_hostname}"
 
 # Try ssh up to 10 times waiting 15 seconds between tries

--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -36,6 +36,11 @@ jobs:
       - name: Setup UDS
         if: always()
         uses: defenseunicorns/uds-common/.github/actions/setup@v0.4.0
+      - name: Setup Tofu
+        uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3
+        with:
+          tofu_wrapper: false
+          tofu_version: 1.6.2
       - name: Publish ${{ matrix.base }} AMI
         run: uds run --no-progress publish-ami-${{ matrix.base }}
       - name: Test ${{ matrix.base }} AMI

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -42,11 +42,11 @@ tasks:
           TEST_AMI_ID=$(jq -r '.builds[-1].artifact_id' ${AWS_DIR}/manifest.json | cut -d ":" -f2)
           echo "TEST AMI: ${TEST_AMI_ID}"
           cd ${E2E_TEST_DIR}/rke2-cluster
-          terraform init -force-copy \
+          tofu init -force-copy \
             -backend-config="bucket=uds-aws-ci-commercial-us-west-2-5246-tfstate" \
             -backend-config="key=tfstate/ci/install/${SHA}-packer-${DISTRO}-rke2-startup-script.tfstate" \
             -backend-config="region=us-west-2"
-          terraform apply -var="ami_id=${TEST_AMI_ID}" -var-file="${DISTRO}.tfvars" -auto-approve
+          tofu apply -var="ami_id=${TEST_AMI_ID}" -var-file="${DISTRO}.tfvars" -auto-approve
           source ${root_dir}/${E2E_TEST_DIR}/scripts/get-kubeconfig.sh
         shell:
           darwin: "bash"
@@ -73,7 +73,7 @@ tasks:
           TEST_AMI_ID=$(jq -r '.builds[-1].artifact_id' ${AWS_DIR}/manifest.json | cut -d ":" -f2)
           echo "TEST AMI: ${TEST_AMI_ID}"
           cd ${E2E_TEST_DIR}/rke2-cluster
-          terraform destroy -var="ami_id=${TEST_AMI_ID}" -var-file="${DISTRO}.tfvars" -auto-approve
+          tofu destroy -var="ami_id=${TEST_AMI_ID}" -var-file="${DISTRO}.tfvars" -auto-approve
 
   - name: cleanup-ami
     description: "Cleans up snapshots and AMIs previously published"


### PR DESCRIPTION
Partially a fix due to CI not pinning the TF install version, conflicting with the constraints we have on TF version: https://github.com/defenseunicorns/uds-rke2-image-builder/actions/runs/8896828233/job/24431171888