### PR TITLE
chore: update renovate config to seperate minor/patch updates for rke2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,13 +13,14 @@
       "matchFileNames": [".github/**"],
       "groupName": "githubactions",
       "commitMessageTopic": "githubactions",
-      "pinDigests": true
+      "pinDigests": true,
+      "excludePackageNames": ["rancher/rke2"]
     },
     {
       "matchDatasources": ["github-releases"],
-      "matchPackageNames": ["rancher/rke2"],
+      "matchDepNames": ["rancher/rke2"],
       "commitMessageTopic": "rke2",
-      "updateTypes": ["patch"]
+      "separateMinorPatch": true
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
Fixes renovate config so that rke2 patch updates are provided in separate PRs.  We want the ability to merge in patch updates only.