### PR TITLE
fix: e2e tests for govcloud/multiple rke2 version fix

### DIFF
--- a/.github/test-infra/rke2-cluster/main.tf
+++ b/.github/test-infra/rke2-cluster/main.tf
@@ -36,7 +36,7 @@ resource "tls_private_key" "example_private_key" {
 }
 
 resource "aws_key_pair" "example_key_pair" {
-  key_name   = var.ssh_key_name
+  key_name   = "${var.ssh_key_name}-${var.rke2_version}"
   public_key = tls_private_key.example_private_key.public_key_openssh
 }
 
@@ -105,7 +105,7 @@ resource "aws_instance" "test_agent_node" {
 }
 
 resource "aws_security_group" "test_node_sg" {
-  name        = "${var.os_distro}-rke2-test-sg"
+  name        = "${var.os_distro}-${var.rke2_version}-rke2-test-sg"
   description = "SG providing settings for RKE2"
   vpc_id      = data.aws_vpc.vpc.id
 

--- a/.github/test-infra/rke2-cluster/variables.tf
+++ b/.github/test-infra/rke2-cluster/variables.tf
@@ -62,6 +62,11 @@ variable "os_distro" {
   description = "OS distribution used to distinguish test infra based on which test created it"
 }
 
+variable "rke2_version" {
+  type        = string
+  description = "RKE2 version used to distinguish test infra based on which test created it"
+}
+
 variable "default_user" {
   type        = string
   description = "Default user of AMI"

--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -58,12 +58,12 @@ jobs:
         shell: bash -e -o pipefail {0}
         env:
           KUBECONFIG: "/home/runner/.kube/rke2-config"
-        run: uds run --no-progress test-cluster --set SHA=${{ github.sha }} --set DISTRO=${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }}
+        run: uds run --no-progress test-cluster --set SHA=${{ github.sha }} --set DISTRO=${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }} --set RKE2_VERSION=${{ matrix.rke2_version }}
       - name: Teardown test infrastructure
         shell: bash -e -o pipefail {0}
         if: always()
-        run: uds run --no-progress teardown-infra --set DISTRO=${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }}
+        run: uds run --no-progress teardown-infra --set DISTRO=${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }} --set RKE2_VERSION=${{ matrix.rke2_version }}
       - name: Cleanup ${{ matrix.base }} ${{ matrix.rke2_version }} AMI on failure
         shell: bash -e -o pipefail {0}
         if: failure()
-        run: uds run --no-progress cleanup-ami --set AWS_REGION=${{ env.AWS_REGION }}
+        run: uds run --no-progress cleanup-ami --set AWS_REGION=${{ env.AWS_REGION }} --set RKE2_VERSION=${{ matrix.rke2_version }}

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -16,6 +16,8 @@ variables:
     description: "AWS region to build the AMI in"
   - name: DISTRO
     description: "The distro to test with for test targets"
+  - name: RKE2_VERSION
+    description: "RKE2 version that is being tested"
   - name: SHA
     description: "The sha to use for the state of the test infra"
 
@@ -38,15 +40,25 @@ tasks:
     description: "Test the AMI with the baked in RKE2 startup script"
     actions:
       - cmd: |
+          # Set variables based on whether we are in govcloud or commercial
+          if [ "$AWS_REGION" == "us-gov-west-1" ]; then
+              state_bucket="uds-ci-govcloud-us-gov-west-1-tfstate"
+              vpc_name="uds-ci-govcloud-*"
+              subnet_name="uds-ci-govcloud-*-public*"
+          else
+              state_bucket="uds-aws-ci-commercial-us-west-2-5246-tfstate"
+              vpc_name="uds-ci-commercial-*"
+              subnet_name="uds-ci-commercial-*-public*"
+          fi
           root_dir=$(pwd)
           TEST_AMI_ID=$(jq -r '.builds[-1].artifact_id' ${AWS_DIR}/manifest.json | cut -d ":" -f2)
           echo "TEST AMI: ${TEST_AMI_ID}"
           cd ${E2E_TEST_DIR}/rke2-cluster
           tofu init -force-copy \
-            -backend-config="bucket=uds-aws-ci-commercial-us-west-2-5246-tfstate" \
-            -backend-config="key=tfstate/ci/install/${SHA}-packer-${DISTRO}-rke2-startup-script.tfstate" \
-            -backend-config="region=us-west-2"
-          tofu apply -var="ami_id=${TEST_AMI_ID}" -var-file="${DISTRO}.tfvars" -auto-approve
+            -backend-config="bucket=${state_bucket}" \
+            -backend-config="key=tfstate/ci/install/${SHA}-packer-${DISTRO}-${RKE2_VERSION}-rke2-startup-script.tfstate" \
+            -backend-config="region=${AWS_REGION}"
+          tofu apply -var="region=${AWS_REGION}" -var="vpc_name=${vpc_name}" -var="subnet_name=${subnet_name}" -var="ami_id=${TEST_AMI_ID}" -var="rke2_version=${RKE2_VERSION}" -var-file="${DISTRO}.tfvars" -auto-approve
           source ${root_dir}/${E2E_TEST_DIR}/scripts/get-kubeconfig.sh
         shell:
           darwin: "bash"
@@ -70,10 +82,18 @@ tasks:
     description: "Destroy test infrastructure"
     actions:
       - cmd: |
+          # Set variables based on whether we are in govcloud or commercial
+          if [ "$AWS_REGION" == "us-gov-west-1" ]; then
+              vpc_name="uds-ci-govcloud-*"
+              subnet_name="uds-ci-govcloud-*-public*"
+          else
+              vpc_name="uds-ci-commercial-*"
+              subnet_name="uds-ci-commercial-*-public*"
+          fi
           TEST_AMI_ID=$(jq -r '.builds[-1].artifact_id' ${AWS_DIR}/manifest.json | cut -d ":" -f2)
           echo "TEST AMI: ${TEST_AMI_ID}"
           cd ${E2E_TEST_DIR}/rke2-cluster
-          tofu destroy -var="ami_id=${TEST_AMI_ID}" -var-file="${DISTRO}.tfvars" -auto-approve
+          tofu destroy -var="region=${AWS_REGION}" -var="vpc_name=${vpc_name}" -var="subnet_name=${subnet_name}" -var="ami_id=${TEST_AMI_ID}" -var="rke2_version=${RKE2_VERSION}" -var-file="${DISTRO}.tfvars" -auto-approve
 
   - name: cleanup-ami
     description: "Cleans up snapshots and AMIs previously published"


### PR DESCRIPTION
Fixes multiple issues that broke e2e tests:

- Conflicting terraform resources (added prefix with rke2 version)
- backend state hardcoded to us-west-1 (added conditional setting for govcloud)
- VPC name/subnet name hardcoded for commercial (added conditional setting for govcloud)