### PR TITLE
chore: add additional triggers to publish aws ami workflow

### DIFF
--- a/.github/workflows/on-pr-aws.yaml
+++ b/.github/workflows/on-pr-aws.yaml
@@ -8,6 +8,7 @@ on:
       - "packer/aws/**"
       - "packer/scripts/**"
       - ".github/workflows/on-pr-aws.yaml"
+      - "tasks/aws.yaml"
 
 permissions:
   id-token: write

--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -8,8 +8,11 @@ on:
       - "packer/aws/**"
       - "packer/scripts/**"
       - ".github/workflows/publish-aws.yaml"
+      - "tasks/aws.yaml"
+      - "tasks/test.yaml"
   schedule:
     - cron: '0 6 1 * *' # Runs monthly at midnight MST
+  workflow_dispatch: # Allows manual triggering of the workflow
 
 permissions:
   id-token: write


### PR DESCRIPTION
Context: This [PR](https://github.com/defenseunicorns/uds-rke2-image-builder/pull/72) probably should have triggered a publishing of the AMIs.

Updated so that: 
1. Changes to `tasks/aws.yaml` and `tasks/test.yaml` trigger a new publish of an AMI.  This workflow directly depends on those files
2. Changes to `tasks/aws.yaml` tigger a PR action
3. Added a workflow dispatch command to build AMIs on demand.