### PR TITLE
fix: make AMIs public

### DIFF
--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -56,7 +56,7 @@ jobs:
           tofu_wrapper: false
           tofu_version: 1.6.2
       - name: Publish ${{ matrix.base }} ${{ matrix.rke2_version }} AMI
-        run: uds run --no-progress publish-ami-${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }} --set RKE2_VERSION=${{ matrix.rke2_version }}
+        run: uds run --no-progress publish-ami-${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }} --set RKE2_VERSION=${{ matrix.rke2_version }} --set PUBLISH_GROUPS='["all"]'
       - name: Test ${{ matrix.base }} ${{ matrix.rke2_version }} AMI
         shell: bash -e -o pipefail {0}
         env:

--- a/packer/aws/rhel.pkrvars.hcl
+++ b/packer/aws/rhel.pkrvars.hcl
@@ -3,4 +3,3 @@ ami_name      = "uds-rhel-rke2"
 base_ami_name = "RHEL-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2"
 ssh_username  = "ec2-user"
 base_ami_owners = ["amazon", "219670896067"]
-ami_groups = ["all"] # makes this AMI public


### PR DESCRIPTION
This makes ubuntu and rhel AWS AMIs public.  The previous attempt in #64 attempted to make this public for rhel, but the `publish-aws.yaml` GHA was overriding the terraform variable.  Setting this parameter in the publish GHA so that it takes precedence.  