### PR TITLE
chore: update uds-common setup to v0.11.2

### DIFF
--- a/.github/workflows/on-pr-aws.yaml
+++ b/.github/workflows/on-pr-aws.yaml
@@ -45,7 +45,7 @@ jobs:
           role-duration-seconds: 21600
       - name: Setup UDS
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/setup@a6fba9c0084319325d70816a3481aec0979649fa # v0.4.0
+        uses: defenseunicorns/uds-common/.github/actions/setup@76287d41ec5f06ecbdd0a6453877a78675aceffe # v0.11.2
       - name: Validate ${{ matrix.base }} ${{ matrix.aws_env }} AMI
         run: uds run --no-progress validate-ami-${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }} --set RKE2_VERSION=${{ matrix.rke2_version }}
       - name: Build ${{ matrix.base }} ${{ matrix.aws_env }} AMI

--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -49,7 +49,7 @@ jobs:
           role-duration-seconds: 21600
       - name: Setup UDS
         if: always()
-        uses: defenseunicorns/uds-common/.github/actions/setup@a6fba9c0084319325d70816a3481aec0979649fa # v0.4.0
+        uses: defenseunicorns/uds-common/.github/actions/setup@76287d41ec5f06ecbdd0a6453877a78675aceffe # v0.11.2
       - name: Setup Tofu
         uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3
         with:


### PR DESCRIPTION
Update the uds-common setup.  This pulls a newer version of uds-cli, which pulls a newer version of maru-runner which adds better [templating](https://github.com/defenseunicorns/maru-runner/releases/tag/v0.2.1).  This should fix the errors in this [run](https://github.com/defenseunicorns/uds-rke2-image-builder/actions/runs/10290136886/job/28479428923#step:7:19) of the publishing job.

Tested in github action run [here](https://github.com/defenseunicorns/uds-rke2-image-builder/actions/runs/10292136302/job/28485891593#step:7:1).  