### PR TITLE
fix: disable public AMIs

### DIFF
--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -56,7 +56,7 @@ jobs:
           tofu_wrapper: false
           tofu_version: 1.6.2
       - name: Publish ${{ matrix.base }} ${{ matrix.rke2_version }} AMI
-        run: uds run --no-progress publish-ami-${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }} --set RKE2_VERSION=${{ matrix.rke2_version }} --set PUBLISH_GROUPS='["all"]'
+        run: uds run --no-progress publish-ami-${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }} --set RKE2_VERSION=${{ matrix.rke2_version }}
       - name: Test ${{ matrix.base }} ${{ matrix.rke2_version }} AMI
         shell: bash -e -o pipefail {0}
         env:


### PR DESCRIPTION
Disabling public AMIs so that we aren't running into AWS account quotas.  It is not the best strategy to publish every version of every AMI as public. We should instead take a released based approach.  Details highlighted in this [issue](https://github.com/defenseunicorns/uds-rke2-image-builder/issues/66).

Disabling so that AMIs are only being published to our internal environment.  Old public AMIs will be cleaned up manually.