### PR TITLE
fix: renovate config match of 10+ patch version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
     {
       "fileMatch": [".*\\.ya?ml$"],
       "matchStrings": [
-        "(?<currentValue>v\\d+\\.\\d+\\.\\d\\+rke2r\\d+)"
+        "(?<currentValue>v\\d+\\.\\d+\\.\\d+\\+rke2r\\d+)"
       ],
       "depNameTemplate": "rancher/rke2",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
Fixes a match to include extra digits on the patch version.