### PR TITLE
fix: update rhel8 build with new stig

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -29,7 +29,7 @@ runs:
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
 
     - name: Setup Tofu
-      uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3
+      uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # v1.0.5
       with:
         tofu_wrapper: false
         tofu_version: 1.6.2

--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -51,7 +51,7 @@ jobs:
         if: always()
         uses: defenseunicorns/uds-common/.github/actions/setup@76287d41ec5f06ecbdd0a6453877a78675aceffe # v0.11.2
       - name: Setup Tofu
-        uses: opentofu/setup-opentofu@ae80d4ecaab946d8f5ff18397fbf6d0686c6d46a # v1.0.3
+        uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # v1.0.5
         with:
           tofu_wrapper: false
           tofu_version: 1.6.2

--- a/packer/scripts/cleanup-deps.sh
+++ b/packer/scripts/cleanup-deps.sh
@@ -8,7 +8,7 @@ DISTRO=$( cat /etc/os-release | tr [:upper:] [:lower:] | grep -Poi '(ubuntu|rhel
 if [[ $DISTRO == "rhel" ]]; then
   yum remove unzip -y
   python3.9 -m pip uninstall ansible
-  yum remove python3.9 python3.9-pip -y
+  yum remove python39 python39-pip -y
 
   # Install nfs-utils here since the STIG profile seems to uninstall it
   yum install nfs-utils -y

--- a/packer/scripts/cleanup-deps.sh
+++ b/packer/scripts/cleanup-deps.sh
@@ -6,7 +6,10 @@ DISTRO=$( cat /etc/os-release | tr [:upper:] [:lower:] | grep -Poi '(ubuntu|rhel
 
 # Cleanup dependencies and utils that shouldn't be in final image
 if [[ $DISTRO == "rhel" ]]; then
-  yum remove unzip ansible -y
+  yum remove unzip -y
+  python3.9 -m pip uninstall ansible
+  yum remove python3.9 python3.9-pip -y
+
   # Install nfs-utils here since the STIG profile seems to uninstall it
   yum install nfs-utils -y
 elif [[ $DISTRO == "ubuntu" ]]; then

--- a/packer/scripts/cleanup-deps.sh
+++ b/packer/scripts/cleanup-deps.sh
@@ -7,7 +7,7 @@ DISTRO=$( cat /etc/os-release | tr [:upper:] [:lower:] | grep -Poi '(ubuntu|rhel
 # Cleanup dependencies and utils that shouldn't be in final image
 if [[ $DISTRO == "rhel" ]]; then
   yum remove unzip -y
-  python3.9 -m pip uninstall ansible
+  python3.9 -m pip uninstall ansible -y
   yum remove python39 python39-pip -y
 
   # Install nfs-utils here since the STIG profile seems to uninstall it

--- a/packer/scripts/install-deps.sh
+++ b/packer/scripts/install-deps.sh
@@ -10,7 +10,15 @@ if [[ $DISTRO == "rhel" ]]; then
   VERSION=$( cat /etc/os-release | grep -Poi '^version="[0-9]+\.[0-9]+' | cut -d\" -f2 | cut -d. -f1 )
 
   yum update -y && yum upgrade -y
-  yum install ansible unzip nfs-utils nfs4-acl-tools lvm2 iscsi-initiator-utils -y
+  yum install unzip nfs-utils nfs4-acl-tools lvm2 iscsi-initiator-utils -y
+
+  # Install Ansible
+  # Note: Latest versions of ansible are not available in RHEL 8 or 9 repos, need to use pip
+  yum install python3.9 python3.9-pip -y # Note python3.9 is the version that currently works with rhel8 STIGs
+  python3.9 -m pip install --upgrade ansible
+  # Temporarily add /usr/local/bin to PATH to ensure ansible is available
+  export PATH=$PATH:/usr/local/bin
+
   #  Install rke2 selinux policy
   if [[ ${VERSION} -eq 9 ]] ; then
     curl -LO "https://github.com/rancher/rke2-selinux/releases/download/v0.18.stable.1/rke2-selinux-0.18-1.el9.noarch.rpm"

--- a/packer/scripts/install-deps.sh
+++ b/packer/scripts/install-deps.sh
@@ -14,7 +14,7 @@ if [[ $DISTRO == "rhel" ]]; then
 
   # Install Ansible
   # Note: Latest versions of ansible are not available in RHEL 8 or 9 repos, need to use pip
-  yum install python3.9 python3.9-pip -y # Note python3.9 is the version that currently works with rhel8 STIGs
+  yum install python39 python39-pip -y # Note python3.9 is the version that currently works with rhel8 STIGs
   python3.9 -m pip install --upgrade ansible
   # Temporarily add /usr/local/bin to PATH to ensure ansible is available
   export PATH=$PATH:/usr/local/bin

--- a/packer/scripts/os-stig.sh
+++ b/packer/scripts/os-stig.sh
@@ -8,11 +8,14 @@ VERSION=$( cat /etc/os-release | grep -Poi '^version="[0-9]+\.[0-9]+' | cut -d\"
 # Pull Ansible STIGs from https://public.cyber.mil/stigs/supplemental-automation-content/
 mkdir -p /tmp/ansible && chmod 700 /tmp/ansible && cd /tmp/ansible
 if [[ $DISTRO == "rhel" ]]; then
+  # Temporarily add /usr/local/bin to PATH to ensure ansible is available as it is installed via pip
+  export PATH=$PATH:/usr/local/bin
+
   # Determine which stigs to apply based on RHEL version
   if [[ ${VERSION} -eq 9 ]] ; then
     curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_RHEL_9_V1R2_STIG_Ansible.zip
   elif [[ ${VERSION} -eq 8 ]]; then
-    curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_RHEL_8_V1R13_STIG_Ansible.zip
+    curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_RHEL_8_V2R2_STIG_Ansible.zip
   else
     echo "Unrecognized RHEL version, exiting"
     exit 1


### PR DESCRIPTION
DISA removed the RHEL8 stig we were relying on: `https://dl.dod.cyber.mil/wpcontent/uploads/stigs/zip/U_RHEL_8_V1R13_STIG_Ansible.zip`

Updating to the newer stig for RHEL8.  This caused some issues as the version of ansible that comes with the yum install is not compatible with this STIG.  All newer versions of ansible must be install with pip.

Updated the ansible installation on rhel to use pip.  

Note: python3.9 was the version of python that I could get working with with these STIGs (3.6 (system), 3.10, 3.11, and 3.12 had compatibility issues)

Also update setup-opentofu to address this [bug](https://github.com/opentofu/setup-opentofu/issues/46).