### PR TITLE
fix: proper packer variable name ami_org_arns

### DIFF
--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -36,12 +36,12 @@ jobs:
             echo "AWS_REGION=us-west-2" >> $GITHUB_ENV
             echo "AWS_ORG_ROLE_TO_ASSUME=${{ secrets.AWS_COMMERCIAL_ORG_ROLE_TO_ASSUME }}" >> $GITHUB_ENV
             echo "AWS_OLD_CI_ACCOUNT_ID=${{ secrets.AWS_OLD_COMMERCIAL_CI_ACCOUNT_ID }}" >> $GITHUB_ENV
-            echo "AWS_ORG_ARN=${{ secrets.AWS_COMMERCIAL_ORG_ARN }}" >> $GITHUB_ENV
+            echo "AMI_ORG_ARN=${{ secrets.AWS_COMMERCIAL_ORG_ARN }}" >> $GITHUB_ENV
           elif [ "${{ matrix.aws_env }}" == "govcloud" ]; then
             echo "AWS_REGION=us-gov-west-1" >> $GITHUB_ENV
             echo "AWS_ORG_ROLE_TO_ASSUME=${{ secrets.AWS_GOVCLOUD_ORG_ROLE_TO_ASSUME }}" >> $GITHUB_ENV
             echo "AWS_OLD_CI_ACCOUNT_ID=${{ secrets.AWS_OLD_GOVCLOUD_CI_ACCOUNT_ID }}" >> $GITHUB_ENV
-            echo "AWS_ORG_ARN=${{ secrets.AWS_GOVCLOUD_ORG_ARN }}" >> $GITHUB_ENV
+            echo "AMI_ORG_ARN=${{ secrets.AWS_GOVCLOUD_ORG_ARN }}" >> $GITHUB_ENV
           fi
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
@@ -59,7 +59,7 @@ jobs:
           tofu_wrapper: false
           tofu_version: 1.6.2
       - name: Publish ${{ matrix.base }} ${{ matrix.rke2_version }} AMI
-        run: uds run --no-progress publish-ami-${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }} --set RKE2_VERSION=${{ matrix.rke2_version }} --set AMI_USERS='["${{ env.AWS_OLD_CI_ACCOUNT_ID }}"]' --set AWS_ORG_ARNS='["${{ env.AWS_ORG_ARN }}"]'
+        run: uds run --no-progress publish-ami-${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }} --set RKE2_VERSION=${{ matrix.rke2_version }} --set AMI_USERS='["${{ env.AWS_OLD_CI_ACCOUNT_ID }}"]' --set AMI_ORG_ARNS='["${{ env.AWS_ORG_ARN }}"]'
       - name: Test ${{ matrix.base }} ${{ matrix.rke2_version }} AMI
         shell: bash -e -o pipefail {0}
         env:

--- a/tasks/aws.yaml
+++ b/tasks/aws.yaml
@@ -14,7 +14,7 @@ variables:
   - name: PUBLISH_GROUPS
     default: "[]"
     description: "List of groups to allow access to the AMI. Only supports '[]' or '[\"all\"]'"
-  - name: AWS_ORG_ARNS
+  - name: AMI_ORG_ARNS
     default: "[]"
     description: "A list of Amazon Resource Names (ARN) of AWS Organizations that have access to launch the resulting AMI(s). By default no organizations have permission to launch the AMI."
   - name: AMI_USERS
@@ -31,7 +31,7 @@ tasks:
       - cmd: |
           cd ${AWS_DIR}
           packer init .
-          packer build -var "ubuntu_pro_token=${UBUNTU_PRO_TOKEN}" --var-file=ubuntu.pkrvars.hcl -var "region=${AWS_REGION}" -var "ami_regions=${PUBLISH_REGIONS}" -var "ami_groups=${PUBLISH_GROUPS}" -var "aws_org_arns=${AWS_ORG_ARNS}" -var "ami_users=${AMI_USERS}" -var "rke2_version=${RKE2_VERSION}" .
+          packer build -var "ubuntu_pro_token=${UBUNTU_PRO_TOKEN}" --var-file=ubuntu.pkrvars.hcl -var "region=${AWS_REGION}" -var "ami_regions=${PUBLISH_REGIONS}" -var "ami_groups=${PUBLISH_GROUPS}" -var "ami_org_arns=${AMI_ORG_ARNS}" -var "ami_users=${AMI_USERS}" -var "rke2_version=${RKE2_VERSION}" .
 
   - name: publish-ami-rhel
     description: "Build and Publish the RHEL AMI for AWS"
@@ -39,7 +39,7 @@ tasks:
       - cmd: |
           cd ${AWS_DIR}
           packer init .
-          packer build --var-file=rhel.pkrvars.hcl -var "region=${AWS_REGION}" -var "ami_regions=${PUBLISH_REGIONS}" -var "ami_groups=${PUBLISH_GROUPS}" -var "aws_org_arns=${AWS_ORG_ARNS}" -var "ami_users=${AMI_USERS}" -var "rke2_version=${RKE2_VERSION}" .
+          packer build --var-file=rhel.pkrvars.hcl -var "region=${AWS_REGION}" -var "ami_regions=${PUBLISH_REGIONS}" -var "ami_groups=${PUBLISH_GROUPS}" -var "ami_org_arns=${AMI_ORG_ARNS}" -var "ami_users=${AMI_USERS}" -var "rke2_version=${RKE2_VERSION}" .
 
   - name: build-ami-ubuntu
     description: "Build the Ubuntu AMI for AWS"


### PR DESCRIPTION
This PR fixes an issue with the variable being passed into the packer execution. The variable name `ami_org_arns` instead of `aws_org_arns`.  Standardizing this with the variable name in the packer docs: https://developer.hashicorp.com/packer/integrations/hashicorp/amazon/latest/components/builder/ebs#ami-configuration