### PR TITLE
chore: update to latest rke2 versions

### DIFF
--- a/.github/workflows/on-pr-aws.yaml
+++ b/.github/workflows/on-pr-aws.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         base: ["ubuntu", "rhel"]
         aws_env: ["commercial", "govcloud"]
-        rke2_version: ["v1.29.10+rke2r1", "v1.30.6+rke2r1", "v1.31.2+rke2r1"]
+        rke2_version: ["v1.30.11+rke2r1", "v1.31.7+rke2r1", "v1.32.3+rke2r1"]
     steps:
       - name: Checkout Code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4

--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         base: ["ubuntu", "rhel"]
         aws_env: ["commercial", "govcloud"]
-        rke2_version: ["v1.29.10+rke2r1", "v1.30.6+rke2r1", "v1.31.2+rke2r1"]
+        rke2_version: ["v1.30.11+rke2r1", "v1.31.7+rke2r1", "v1.32.3+rke2r1"]
     steps:
       - name: Checkout Code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4

--- a/tasks/aws.yaml
+++ b/tasks/aws.yaml
@@ -21,7 +21,7 @@ variables:
     default: "[]"
     description: "A list of account IDs that have access to launch the resulting AMI(s). By default no additional users other than the user creating the AMI has permissions to launch it."
   - name: RKE2_VERSION
-    default: "v1.29.10+rke2r1"
+    default: "v1.31.7+rke2r1"
     description: "RKE2 version to build the AMI with"
 
 tasks:


### PR DESCRIPTION
Updates to the latest patch versions of 1.30, 1.31, and 1.32. Adds 1.32 and removes 1.29 based on EOL