### PR TITLE
chore: update rke2 versions, ubuntu stig

### DIFF
--- a/.github/workflows/on-pr-aws.yaml
+++ b/.github/workflows/on-pr-aws.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         base: ["ubuntu", "rhel"]
         aws_env: ["commercial", "govcloud"]
-        rke2_version: ["v1.30.11+rke2r1", "v1.31.7+rke2r1", "v1.32.3+rke2r1"]
+        rke2_version: ["v1.31.9+rke2r1", "v1.32.5+rke2r1", "v1.33.1+rke2r1"]
     steps:
       - name: Checkout Code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4

--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         base: ["ubuntu", "rhel"]
         aws_env: ["commercial", "govcloud"]
-        rke2_version: ["v1.30.11+rke2r1", "v1.31.7+rke2r1", "v1.32.3+rke2r1"]
+        rke2_version: ["v1.31.9+rke2r1", "v1.32.5+rke2r1", "v1.33.1+rke2r1"]
     steps:
       - name: Checkout Code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4

--- a/packer/scripts/os-stig.sh
+++ b/packer/scripts/os-stig.sh
@@ -22,8 +22,7 @@ if [[ $DISTRO == "rhel" ]]; then
   fi
 elif [[ $DISTRO == "ubuntu" ]]; then
   if [[ ${VERSION} -eq 22 ]] ; then
-    # Currently there is no stig available for Ubuntu 22.04
-    curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_CAN_Ubuntu_20-04_LTS_V1R11_STIG_Ansible.zip
+    curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_CAN_Ubuntu_22-04_LTS_V2R4_STIG_Ansible.zip
   elif [[ ${VERSION} -eq 20 ]]; then
     curl -L -o ansible.zip https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_CAN_Ubuntu_20-04_LTS_V1R11_STIG_Ansible.zip
   else

--- a/tasks/aws.yaml
+++ b/tasks/aws.yaml
@@ -21,7 +21,7 @@ variables:
     default: "[]"
     description: "A list of account IDs that have access to launch the resulting AMI(s). By default no additional users other than the user creating the AMI has permissions to launch it."
   - name: RKE2_VERSION
-    default: "v1.31.7+rke2r1"
+    default: "v1.32.5+rke2r1"
     description: "RKE2 version to build the AMI with"
 
 tasks:


### PR DESCRIPTION
Updates to the latest 3 RKE2 versions + adds the new ubuntu 22 stig.