### PR TITLE
chore: update to RHEL9, Ubuntu 22, RKE2 1.32.6

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -34,9 +34,11 @@ runs:
         tofu_wrapper: false
         tofu_version: 1.6.2
 
-    - name: Setup UDS
-      if: always()
-      uses: defenseunicorns/uds-common/.github/actions/setup@a6fba9c0084319325d70816a3481aec0979649fa # v0.4.0
+    - name: Install UDS CLI
+      uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
+      with:
+        # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
+        version: v0.27.7
 
     - name: Validate ${{ inputs.distro }} AMI
       shell: bash -e -o pipefail {0}

--- a/.github/test-infra/manifests/test.yaml
+++ b/.github/test-infra/manifests/test.yaml
@@ -13,6 +13,6 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: ghcr.io/stefanprodan/podinfo:6.6.2@sha256:4aa3b819f4cafc97d03d902ed17cbec076e2beee02d53b67ff88527124086fd9
+      image: ghcr.io/stefanprodan/podinfo:6.9.0@sha256:10af81c9659824cecaa7fe09134c6c318136341b4ae84c4a37f18d9bd8a33eac
       command:
         - ./podinfo

--- a/.github/workflows/on-pr-aws.yaml
+++ b/.github/workflows/on-pr-aws.yaml
@@ -22,10 +22,10 @@ jobs:
       matrix:
         base: ["ubuntu", "rhel"]
         aws_env: ["commercial", "govcloud"]
-        rke2_version: ["v1.32.6+rke2r1]
+        rke2_version: ["v1.32.6+rke2r1"]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set AWS Variables
         run: |
           if [ "${{ matrix.aws_env }}" == "commercial" ]; then

--- a/.github/workflows/on-pr-aws.yaml
+++ b/.github/workflows/on-pr-aws.yaml
@@ -22,10 +22,10 @@ jobs:
       matrix:
         base: ["ubuntu", "rhel"]
         aws_env: ["commercial", "govcloud"]
-        rke2_version: ["v1.31.9+rke2r1", "v1.32.5+rke2r1", "v1.33.1+rke2r1"]
+        rke2_version: ["v1.32.6+rke2r1]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set AWS Variables
         run: |
           if [ "${{ matrix.aws_env }}" == "commercial" ]; then
@@ -42,9 +42,11 @@ jobs:
           role-session-name: ${{ github.job || github.event.client_payload.pull_request.head.sha || github.sha }}
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 3600
-      - name: Setup UDS
-        if: always()
-        uses: defenseunicorns/uds-common/.github/actions/setup@76287d41ec5f06ecbdd0a6453877a78675aceffe # v0.11.2
+      - name: Install UDS CLI
+        uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
+        with:
+          # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
+          version: v0.27.7
       - name: Validate ${{ matrix.base }} ${{ matrix.aws_env }} AMI
         run: uds run --no-progress validate-ami-${{ matrix.base }} --set AWS_REGION=${{ env.AWS_REGION }} --set RKE2_VERSION=${{ matrix.rke2_version }}
       - name: Build ${{ matrix.base }} ${{ matrix.aws_env }} AMI

--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -29,7 +29,7 @@ jobs:
         rke2_version: ["v1.32.6+rke2r1"]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set AWS Variables
         run: |
           if [ "${{ matrix.aws_env }}" == "commercial" ]; then

--- a/.github/workflows/publish-aws.yaml
+++ b/.github/workflows/publish-aws.yaml
@@ -26,10 +26,10 @@ jobs:
       matrix:
         base: ["ubuntu", "rhel"]
         aws_env: ["commercial", "govcloud"]
-        rke2_version: ["v1.31.9+rke2r1", "v1.32.5+rke2r1", "v1.33.1+rke2r1"]
+        rke2_version: ["v1.32.6+rke2r1"]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set AWS Variables
         run: |
           if [ "${{ matrix.aws_env }}" == "commercial" ]; then
@@ -50,9 +50,11 @@ jobs:
           role-session-name: ${{ github.job || github.event.client_payload.pull_request.head.sha || github.sha }}
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 3600
-      - name: Setup UDS
-        if: always()
-        uses: defenseunicorns/uds-common/.github/actions/setup@76287d41ec5f06ecbdd0a6453877a78675aceffe # v0.11.2
+      - name: Install UDS CLI
+        uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
+        with:
+          # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
+          version: v0.27.7
       - name: Setup Tofu
         uses: opentofu/setup-opentofu@592200bd4b9bbf4772ace78f887668b1aee8f716 # v1.0.5
         with:

--- a/.github/workflows/test-rke2-cluster.yaml
+++ b/.github/workflows/test-rke2-cluster.yaml
@@ -26,7 +26,7 @@ jobs:
       test-distros: ${{ steps.parse.outputs.test-distros }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
@@ -57,7 +57,7 @@ jobs:
     if: needs.parse.outputs.run-ping == 'true'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/test-rke2-cluster.yaml
+++ b/.github/workflows/test-rke2-cluster.yaml
@@ -26,7 +26,7 @@ jobs:
       test-distros: ${{ steps.parse.outputs.test-distros }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
@@ -57,7 +57,7 @@ jobs:
     if: needs.parse.outputs.run-ping == 'true'
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UDS RKE2 Image Builder
 
 This repo contains Packer code to produce STIG'd RKE2 images for various environments. Built images will have:
-- Base OS (currently supporting RHEL 8 and Ubuntu 20.04)
+- Base OS (currently supporting RHEL and Ubuntu)
 - STIGs applied to the OS
 - RKE2 pre-installed, STIG'd, and airgap ready (all images pre-installed)
 

--- a/packer/aws/rhel.pkrvars.hcl
+++ b/packer/aws/rhel.pkrvars.hcl
@@ -1,5 +1,5 @@
 // Input variable values for a RHEL based RKE2 AMI
 ami_name      = "uds-rhel-rke2"
-base_ami_name = "RHEL-8.8.0_HVM-20230623-x86_64-3-Hourly2-GP2"
+base_ami_name = "RHEL-9.*.0_HVM-*-x86_64-16-Hourly2-GP3"
 ssh_username  = "ec2-user"
 base_ami_owners = ["amazon", "219670896067"]

--- a/packer/aws/ubuntu.pkrvars.hcl
+++ b/packer/aws/ubuntu.pkrvars.hcl
@@ -1,5 +1,5 @@
 // Input variable values for an Ubuntu based RKE2 AMI
 ami_name      = "uds-ubuntu-rke2"
-base_ami_name = "ubuntu-pro-server/images/hvm-ssd/ubuntu-focal-20.04-amd64-pro-server-202*"
+base_ami_name = "ubuntu-pro-server/images/hvm-ssd/ubuntu-jammy-22.04-amd64-pro-server-202*"
 ssh_username  = "ubuntu"
 base_ami_owners = ["amazon", "513442679011"] # 513442679011 is Ubuntu if GovCloud

--- a/tasks/aws.yaml
+++ b/tasks/aws.yaml
@@ -21,7 +21,7 @@ variables:
     default: "[]"
     description: "A list of account IDs that have access to launch the resulting AMI(s). By default no additional users other than the user creating the AMI has permissions to launch it."
   - name: RKE2_VERSION
-    default: "v1.32.5+rke2r1"
+    default: "v1.32.6+rke2r1"
     description: "RKE2 version to build the AMI with"
 
 tasks:


### PR DESCRIPTION
Updates:
- RKE2 1.32.6 by default, removed other versions from CI testing/publish
- RHEL 9 by default
- Ubuntu 22 by default
- Update to use `setup-uds` for installing uds-cli
- Updated podinfo to 6.9.0
- Updated checkout action to latest

This incorporates all the changes from https://github.com/defenseunicorns/uds-rke2-image-builder/pull/55 minus the uds-common updates since those are no longer needed with setup-uds.