### PR TITLE
fix: restore proper DNS and networking on latest RHEL

### DIFF
--- a/packer/scripts/os-prep.sh
+++ b/packer/scripts/os-prep.sh
@@ -50,7 +50,7 @@ if systemctl list-units --full | grep -Poi "NetworkManager.service" &>/dev/null;
   # Indent with tabs to prevent spaces in heredoc output
 	cat <<- EOF > /etc/NetworkManager/conf.d/rke2-canal.conf
 	[keyfile]
-	unmanaged-devices=interface-name:cali*;interface-name:flannel*
+	unmanaged-devices=interface-name:flannel*;interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico;interface-name:wireguard.cali;interface-name:wg-v6.cali
 	EOF
   systemctl reload NetworkManager
 fi
@@ -58,8 +58,8 @@ fi
 # If present, disable services that interfere with cluster networking - https://docs.rke2.io/known_issues#firewalld-conflicts-with-default-networking
 services_to_disable=("firewalld" "nm-cloud-setup" "nm-cloud-setup.timer")
 for service in "${services_to_disable[@]}"; do
-  if systemctl list-units --full -all | grep -Poi "$service.service" &>/dev/null; then
-    systemctl stop "$service.service"
-    systemctl disable "$service.service"
+  if systemctl list-units --full -all | grep -Poi "$service" &>/dev/null; then
+    systemctl stop "$service"
+    systemctl disable "$service"
   fi
 done

--- a/packer/scripts/os-prep.sh
+++ b/packer/scripts/os-prep.sh
@@ -46,11 +46,16 @@ elif [[ $DISTRO == "ubuntu" ]]; then
 fi
 
 # If Network Manager is being used configure it to ignore calico/flannel network interfaces - https://docs.rke2.io/known_issues#networkmanager
+# On RHEL9 DNS is set to none by the STIG script default values
 if systemctl list-units --full | grep -Poi "NetworkManager.service" &>/dev/null; then
   # Indent with tabs to prevent spaces in heredoc output
 	cat <<- EOF > /etc/NetworkManager/conf.d/rke2-canal.conf
 	[keyfile]
 	unmanaged-devices=interface-name:flannel*;interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico;interface-name:wireguard.cali;interface-name:wg-v6.cali
+	EOF
+	cat <<- EOF > /etc/NetworkManager/conf.d/dns-default.conf
+	[main]
+	dns=default
 	EOF
   systemctl reload NetworkManager
 fi


### PR DESCRIPTION
Updated os-prep based on updated RKE2 documentation: https://docs.rke2.io/known_issues

Also discovered that the latest STIG for RHEL9 defaults to disabling DNS. This is an ansible var where the default is "none" for DNS, but overwriting with a basic conf file is the simplest path here.